### PR TITLE
petit correctif

### DIFF
--- a/Events/BountyIncurredEvent .cs
+++ b/Events/BountyIncurredEvent .cs
@@ -24,19 +24,8 @@ namespace EddiEvents
 
         [JsonProperty("crimetype")]
         public string crimetype { get; private set; }
-        public string LocalCrimeType
-        {
-            get
-            {
-                if (crimetype != null && crimetype != "")
-                {
-                    return Crime.FromName(crimetype).LocalName;
-                }
-                else return null;
-            }
-        }
 
-		[JsonIgnore]
+	[JsonIgnore]
         public string LocalCrime
         {
             get

--- a/Events/FineIncurredEvent.cs
+++ b/Events/FineIncurredEvent.cs
@@ -1,4 +1,4 @@
-﻿using EddiDataDefinitions;
+using EddiDataDefinitions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -15,7 +15,6 @@ namespace EddiEvents
         static FineIncurredEvent()
         {
             VARIABLES.Add("crimetype", "The type of crime committed");
-            VARIABLES.Add("LocalCrimeType", "The translation of the crime into the chosen language");
             VARIABLES.Add("crimedescription", "The decription of the crime committed");
             VARIABLES.Add("LocalCrime", "The localized decription of the crime committed");
             VARIABLES.Add("victim", "The name of the victim of the crime");
@@ -25,7 +24,6 @@ namespace EddiEvents
 
         [JsonProperty("crimetype")]
         public string crimetype { get; private set; }
-
         
         public string LocalCrime
         {
@@ -40,19 +38,6 @@ namespace EddiEvents
         }
 
         public string crime { get; private set; }
-
-        [JsonProperty("LocalCrimeType")]
-        public string LocalCrimeType
-        {
-            get
-            {
-                if (crimetype != null && crimetype != "")
-                {
-                    return Crime.FromName(crimetype).LocalName;
-                }
-                else return null;
-            }
-        }
 
         [JsonProperty("victim")]
         public string victim { get; private set; }


### PR DESCRIPTION
correctif suite à un signal d'erreur ==> There is a problem with the script: Une exception a été levée par la cible dun appel 
sur BountyIncurredEvent .cs (ligne33) et FineIncurredEvent.cs ligne 51
l’occurrence crimetype contient le 'edname', l’occurrence 'crime' contient le 'name', d'où surement l'erreur à y chercher le 'name', avoir deux fois le 'LocalName' sous deux appellations différentes devient moins intéressant d'où ne garder que 'LocalCrime' plus court à taper.