### PR TITLE
correctif CommodityCollectedEvent

### DIFF
--- a/Events/CommodityCollectedEvent.cs
+++ b/Events/CommodityCollectedEvent.cs
@@ -1,7 +1,8 @@
-﻿using EddiDataDefinitions;
+using EddiDataDefinitions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Utilities;
 
 namespace EddiEvents
 {
@@ -23,17 +24,7 @@ namespace EddiEvents
         public string commodity { get; private set; }
 
         [JsonProperty("LocalCommodity")]
-        public string LocalCommodity
-        {
-            get
-            {
-                if (commodity != null && commodity != "")
-                {
-                    return CommodityDefinitions.FromName(commodity).LocalName;
-                }
-                else return null;
-            }
-        }
+        public string LocalCommodity { get; }
 
 
 
@@ -43,6 +34,7 @@ namespace EddiEvents
         public CommodityCollectedEvent(DateTime timestamp, Commodity commodity, bool stolen) : base(timestamp, NAME)
         {
             this.commodity = (commodity == null ? "unknown commodity" : commodity.name);
+            this.LocalCommodity = (commodity == null ? "unknown commodity" : commodity.LocalName);
             this.stolen = stolen;
         }
     }


### PR DESCRIPTION
L'ancien code ne marchait pas bien avec les noms composés (par exemple syntheticfabrics devrait donner Tissus synthétiques, mais ne donnait que le nom en anglais Synthetic Fabrics), cela ne marchait qu'avec les noms simple (comme biowaste pour Biodéchets avec lesquels j’avais fait mes essais préliminaires), la structure a donc un peut changer pour aller chercher directement le Local dans l'objet.